### PR TITLE
avbryter meldinger hvis det finnes nyere planlagte meldinger

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.aktivermelding.db
 
 import java.sql.Connection
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 import no.nav.syfo.application.db.DatabaseInterface
@@ -12,6 +13,12 @@ import no.nav.syfo.model.toPlanlagtMeldingDbModel
 fun DatabaseInterface.hentPlanlagtMelding(id: UUID): PlanlagtMeldingDbModel? {
     connection.use { connection ->
         return connection.hentPlanlagtMelding(id)
+    }
+}
+
+fun DatabaseInterface.finnesPlanlagtMeldingMedNyereStartdato(fnr: String, startdato: LocalDate): Boolean {
+    connection.use { connection ->
+        return connection.finnesPlanlagtMeldingMedNyereStartdato(fnr, startdato)
     }
 }
 
@@ -50,6 +57,17 @@ private fun Connection.hentPlanlagtMelding(id: UUID): PlanlagtMeldingDbModel? =
     ).use {
         it.setObject(1, id)
         it.executeQuery().toList { toPlanlagtMeldingDbModel() }.firstOrNull()
+    }
+
+private fun Connection.finnesPlanlagtMeldingMedNyereStartdato(fnr: String, startdato: LocalDate): Boolean =
+    this.prepareStatement(
+        """
+            SELECT 1 FROM planlagt_melding WHERE fnr=? AND startdato>?;
+            """
+    ).use {
+        it.setString(1, fnr)
+        it.setObject(2, startdato)
+        it.executeQuery().next()
     }
 
 private fun Connection.avbrytPlanlagtMelding(id: UUID, avbrutt: OffsetDateTime) =


### PR DESCRIPTION
Denne PR-en skal rette opp i en feil der vi sender meldinger for tidligere sykefravær til Arena. For eksempel: Hvis bruker er sykmeldt fra 1/1 til 20/1, og så er frisk en måneds tid, men blir sykmeldt igjen fra 15/2. Når de planlagte meldingene fra første sykefravær treffer 4-, 8- og 39-ukerstidspunkt kan det godt hende at brukeren fortsatt er sykmeldt, men da gjelder sykmeldingen det andre sykefraværet. Dermed sender vi meldinger for det første sykefraværet, og det blir ikke riktig. 

Med denne PR-en sjekker vi først om det finnes planlagte meldinger for sykefravær med nyere startdato. Hvis det finnes avbryter vi meldingen vi var på vei til å sende til Arena. Hvis ikke sjekker vi om bruker fortsatt er sykmeldt, som før. 