### PR TITLE
Stans

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
@@ -3,22 +3,27 @@ package no.nav.syfo.aktivermelding
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.util.KtorExperimentalAPI
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import no.nav.syfo.aktivermelding.client.SmregisterClient
 import no.nav.syfo.aktivermelding.db.avbrytPlanlagtMelding
 import no.nav.syfo.aktivermelding.db.finnesPlanlagtMeldingMedNyereStartdato
 import no.nav.syfo.aktivermelding.db.hentPlanlagtMelding
 import no.nav.syfo.aktivermelding.db.sendPlanlagtMelding
+import no.nav.syfo.aktivermelding.db.utsettPlanlagtMelding
 import no.nav.syfo.aktivermelding.kafka.model.AktiverMelding
 import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.metrics.AVBRUTT_MELDING
 import no.nav.syfo.application.metrics.IKKE_FUNNET_MELDING
 import no.nav.syfo.application.metrics.MOTTATT_AKTIVERMELDING
 import no.nav.syfo.application.metrics.SENDT_MELDING
+import no.nav.syfo.application.metrics.UTSATT_MELDING
 import no.nav.syfo.log
 import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
 import no.nav.syfo.model.BREV_4_UKER_TYPE
+import no.nav.syfo.model.PlanlagtMeldingDbModel
+import no.nav.syfo.model.STANS_TYPE
 import no.nav.syfo.objectMapper
 
 @KtorExperimentalAPI
@@ -37,9 +42,15 @@ class AktiverMeldingService(
     suspend fun behandleAktiverMelding(aktiverMelding: AktiverMelding) {
         val planlagtMelding = database.hentPlanlagtMelding(aktiverMelding.id)
         if (planlagtMelding != null) {
-            val finnesPlanlagtMeldingMedNyereStartdato = database.finnesPlanlagtMeldingMedNyereStartdato(planlagtMelding.fnr, planlagtMelding.startdato)
-            val skalSendeMelding = if (!finnesPlanlagtMeldingMedNyereStartdato) {
-                when (planlagtMelding.type) {
+            val finnesPlanlagtMeldingMedNyereStartdato =
+                database.finnesPlanlagtMeldingMedNyereStartdato(planlagtMelding.fnr, planlagtMelding.startdato)
+            if (finnesPlanlagtMeldingMedNyereStartdato) {
+                log.info("Det finnes planlagte meldinger for sykefravær med nyere startdato, avbryter melding med id ${planlagtMelding.id}")
+                avbrytMelding(aktiverMelding)
+            } else if (planlagtMelding.type == STANS_TYPE) {
+                sendEllerUtsettStansmelding(planlagtMelding)
+            } else {
+                val skalSendeMelding = when (planlagtMelding.type) {
                     BREV_4_UKER_TYPE -> {
                         smregisterClient.erSykmeldt(planlagtMelding.fnr, aktiverMelding.id)
                     }
@@ -54,23 +65,40 @@ class AktiverMeldingService(
                         throw IllegalStateException("Planlagt melding har ukjent type")
                     }
                 }
-            } else {
-                log.info("Det finnes planlagte meldinger for sykefravær med nyere startdato, avbryter melding med id ${planlagtMelding.id}")
-                false
-            }
-            if (skalSendeMelding) {
-                log.info("Sender melding med id {} til Arena", aktiverMelding.id)
-                arenaMeldingService.sendPlanlagtMeldingTilArena(planlagtMelding)
-                database.sendPlanlagtMelding(aktiverMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
-                SENDT_MELDING.inc()
-            } else {
-                log.info("Avbryter melding med id {}", aktiverMelding.id)
-                database.avbrytPlanlagtMelding(aktiverMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
-                AVBRUTT_MELDING.inc()
+                if (skalSendeMelding) {
+                    sendTilArena(planlagtMelding)
+                } else {
+                    avbrytMelding(aktiverMelding)
+                }
             }
         } else {
             log.warn("Fant ikke planlagt melding for id ${aktiverMelding.id} som ikke er sendt eller avbrutt fra før")
             IKKE_FUNNET_MELDING.inc()
         }
+    }
+
+    private suspend fun sendEllerUtsettStansmelding(planlagtMelding: PlanlagtMeldingDbModel) {
+        val sykmeldtTom = smregisterClient.erSykmeldtTilOgMed(planlagtMelding.fnr, planlagtMelding.id)
+        if (sykmeldtTom == null) {
+            log.info("Bruker er ikke lenger sykmeldt, aktiverer stansmelding ${planlagtMelding.id}")
+            sendTilArena(planlagtMelding)
+        } else {
+            log.info("Bruker er fortsatt sykmeldt, utsetter stansmelding ${planlagtMelding.id}")
+            database.utsettPlanlagtMelding(planlagtMelding.id, sykmeldtTom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime())
+            UTSATT_MELDING.inc()
+        }
+    }
+
+    private fun sendTilArena(planlagtMelding: PlanlagtMeldingDbModel) {
+        log.info("Sender melding med id {} til Arena", planlagtMelding.id)
+        arenaMeldingService.sendPlanlagtMeldingTilArena(planlagtMelding)
+        database.sendPlanlagtMelding(planlagtMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
+        SENDT_MELDING.inc()
+    }
+
+    private fun avbrytMelding(aktiverMelding: AktiverMelding) {
+        log.info("Avbryter melding med id {}", aktiverMelding.id)
+        database.avbrytPlanlagtMelding(aktiverMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
+        AVBRUTT_MELDING.inc()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingService.kt
@@ -7,10 +7,15 @@ import java.time.format.DateTimeFormatter
 import no.nav.syfo.aktivermelding.arenamodel.Aktivitetskrav8UkerMelding
 import no.nav.syfo.aktivermelding.arenamodel.Brev39UkerMelding
 import no.nav.syfo.aktivermelding.arenamodel.Brev4UkerMelding
+import no.nav.syfo.aktivermelding.arenamodel.K278M810Stans
+import no.nav.syfo.aktivermelding.arenamodel.K278M815Stans
+import no.nav.syfo.aktivermelding.arenamodel.K278M830Stans
+import no.nav.syfo.aktivermelding.arenamodel.K278M840Stans
 import no.nav.syfo.aktivermelding.arenamodel.N2810
 import no.nav.syfo.aktivermelding.arenamodel.N2820
 import no.nav.syfo.aktivermelding.arenamodel.N2830
 import no.nav.syfo.aktivermelding.arenamodel.N2840
+import no.nav.syfo.aktivermelding.arenamodel.Stansmelding
 import no.nav.syfo.aktivermelding.arenamodel.tilMqMelding
 import no.nav.syfo.aktivermelding.mq.ArenaMqProducer
 import no.nav.syfo.log
@@ -18,6 +23,7 @@ import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
 import no.nav.syfo.model.BREV_4_UKER_TYPE
 import no.nav.syfo.model.PlanlagtMeldingDbModel
+import no.nav.syfo.model.STANS_TYPE
 
 class ArenaMeldingService(
     private val arenaMqProducer: ArenaMqProducer
@@ -47,6 +53,15 @@ class ArenaMeldingService(
             BREV_39_UKER_TYPE -> {
                 arenaMqProducer.sendTilArena(
                     til39Ukersmelding(
+                        planlagtMeldingDbModel,
+                        OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
+                    ).tilMqMelding()
+                )
+                log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}")
+            }
+            STANS_TYPE -> {
+                arenaMqProducer.sendTilArena(
+                    tilStansmelding(
                         planlagtMeldingDbModel,
                         OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
                     ).tilMqMelding()
@@ -130,6 +145,22 @@ class ArenaMeldingService(
                     ' '
                 )
             )
+        )
+    }
+
+    fun tilStansmelding(planlagtMeldingDbModel: PlanlagtMeldingDbModel, now: OffsetDateTime): Stansmelding {
+        val nowFormatted = formatDateTime(now)
+        return Stansmelding(
+            k278M810 = K278M810Stans(
+                dato = nowFormatted.split(',')[0],
+                klokke = nowFormatted.split(',')[1],
+                fnr = planlagtMeldingDbModel.fnr
+            ),
+            k278M815 = K278M815Stans(),
+            k278M830 = K278M830Stans(
+                startdato = formatDate(planlagtMeldingDbModel.startdato)
+            ),
+            k278M840 = K278M840Stans()
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/arenamodel/Stansmelding.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/arenamodel/Stansmelding.kt
@@ -1,0 +1,151 @@
+package no.nav.syfo.aktivermelding.arenamodel
+
+import no.nav.syfo.log
+
+data class Stansmelding(
+    val k278M810: K278M810Stans,
+    val k278M815: K278M815Stans,
+    val k278M830: K278M830Stans,
+    val k278M840: K278M840Stans
+)
+
+data class K278M810Stans(
+    val copyId: String = "K278M810", // lengde 8
+    val aksjon: String = "SENDMELDING", // lengde 11
+    val kilde: String = "SPEIL", // lengde 5
+    val brukerId: String = "".padEnd(8, ' '), // lengde 8, brukes ikke
+    val mlen: String = "00482", // lengde 5, totallengde
+    val dato: String, // lengde 8, dagens dato
+    val klokke: String, // lengde 6, klokkeslett nå
+    val navKontor: String = "".padEnd(4, ' '), // lengde 4, brukes ikke
+    val fnr: String, // lengde 11
+    val spesRolle: String = " ", // lengde 1, brukes ikke
+    val navAnsatt: String = " ", // lengde 1, brukes ikke
+    val ytelse: String = "SP", // lengde 2
+    val meldKode: String = "O", // lengde 1
+    val uaktuell: String = " " // lengde 1
+)
+
+data class K278M815Stans(
+    val copyId: String = "K278M815", // lengde 8
+    val antall: String = "00001", // lengde 5
+    val fornavn: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val mellomnavn: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val etternavn: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val adresse1: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val adresse2: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val adresse3: String = "".padEnd(30, ' '), // lengde 30, brukes ikke
+    val postnr: String = "".padEnd(4, ' '), // lengde 4, brukes ikke
+    val bokommune: String = "".padEnd(4, ' ') // lengde 4, brukes ikke
+)
+
+data class K278M830Stans(
+    val copyId: String = "K278M830", // lengde 8
+    val antall: String = "00001", // lengde 5
+    val meldingId: String = "M-SPUB-1".padEnd(10, ' '), // lengde 10
+    val versjon: String = "005", // lengde 3
+    val startdato: String, // lengde 8
+    val stanskode: String = "AA", // lengde 2
+    val stanstekst: String = "AVSLUTTET".padEnd(50, ' '), // lengde 50
+    val filler: String = "".padEnd(30, ' ') // lengde 30
+)
+
+data class K278M840Stans(
+    val copyId: String = "K278M840", // lengde 8
+    val antall: String = "00001", // lengde 5
+    val taglinje: String = "SP: SP sykepenger er stanset".padEnd(80, ' ') // lengde 80
+)
+
+fun Stansmelding.tilMqMelding(): String {
+    val sb = StringBuilder()
+    sb.append(k278M810.tilTekst())
+    sb.append(k278M815.tilTekst())
+    sb.append(k278M830.tilTekst())
+    sb.append(k278M840.tilTekst())
+
+    val stansmeldingSomTekst = sb.toString()
+    if (stansmeldingSomTekst.length != 482) {
+        log.error("Stansmelding har feil lengde: ${stansmeldingSomTekst.length}")
+        throw IllegalStateException("Stansmelding har feil lengde")
+    }
+    return stansmeldingSomTekst
+}
+
+fun K278M810Stans.tilTekst(): String {
+    val sb = StringBuilder()
+    sb.append(copyId)
+    sb.append(aksjon)
+    sb.append(kilde)
+    sb.append(brukerId)
+    sb.append(mlen)
+    sb.append(dato)
+    sb.append(klokke)
+    sb.append(navKontor)
+    sb.append(fnr)
+    sb.append(spesRolle)
+    sb.append(navAnsatt)
+    sb.append(ytelse)
+    sb.append(meldKode)
+    sb.append(uaktuell)
+
+    val k278M810SomTekst = sb.toString()
+    if (k278M810SomTekst.length != 72) {
+        log.error("K278M810 (stans) har feil lengde: ${k278M810SomTekst.length}")
+        throw IllegalStateException("K278M810 har feil lengde")
+    }
+    return k278M810SomTekst
+}
+
+fun K278M815Stans.tilTekst(): String {
+    val sb = StringBuilder()
+    sb.append(copyId)
+    sb.append(antall)
+    sb.append(fornavn)
+    sb.append(mellomnavn)
+    sb.append(etternavn)
+    sb.append(adresse1)
+    sb.append(adresse2)
+    sb.append(adresse3)
+    sb.append(postnr)
+    sb.append(bokommune)
+
+    val k278M815SomTekst = sb.toString()
+    if (k278M815SomTekst.length != 201) {
+        log.error("K278M815 (stans) har feil lengde: ${k278M815SomTekst.length}")
+        throw IllegalStateException("K278M815 har feil lengde")
+    }
+    return k278M815SomTekst
+}
+
+fun K278M830Stans.tilTekst(): String {
+    val sb = StringBuilder()
+    sb.append(copyId)
+    sb.append(antall)
+    sb.append(meldingId)
+    sb.append(versjon)
+    sb.append(startdato)
+    sb.append(stanskode)
+    sb.append(stanstekst)
+    sb.append(filler)
+
+    val k278M830SomTekst = sb.toString()
+    if (k278M830SomTekst.length != 116) {
+        log.error("K278M830 (stans) har feil lengde: ${k278M830SomTekst.length}")
+        throw IllegalStateException("K278M830 har feil lengde")
+    }
+    return k278M830SomTekst
+}
+
+fun K278M840Stans.tilTekst(): String {
+    val sb = StringBuilder()
+    sb.append(copyId)
+    sb.append(antall)
+    sb.append(taglinje)
+
+    val k278M840SomTekst = sb.toString()
+    if (k278M840SomTekst.length != 93) {
+        log.error("K278M840 (stans) har feil lengde: ${k278M840SomTekst.length}")
+        throw IllegalStateException("K278M840 har feil lengde")
+    }
+    return k278M840SomTekst
+}

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -29,6 +29,13 @@ fun DatabaseInterface.avbrytPlanlagtMelding(id: UUID, avbrutt: OffsetDateTime) {
     }
 }
 
+fun DatabaseInterface.utsettPlanlagtMelding(id: UUID, sendes: OffsetDateTime) {
+    connection.use { connection ->
+        connection.utsettPlanlagtMelding(id, sendes)
+        connection.commit()
+    }
+}
+
 fun DatabaseInterface.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime) {
     connection.use { connection ->
         connection.sendPlanlagtMelding(id, sendt)
@@ -77,6 +84,17 @@ private fun Connection.avbrytPlanlagtMelding(id: UUID, avbrutt: OffsetDateTime) 
             """
     ).use {
         it.setTimestamp(1, Timestamp.from(avbrutt.toInstant()))
+        it.setObject(2, id)
+        it.execute()
+    }
+
+private fun Connection.utsettPlanlagtMelding(id: UUID, sendes: OffsetDateTime) =
+    this.prepareStatement(
+        """
+            UPDATE planlagt_melding SET sendes=? WHERE id=?;
+            """
+    ).use {
+        it.setTimestamp(1, Timestamp.from(sendes.toInstant()))
         it.setObject(2, id)
         it.execute()
     }

--- a/src/main/kotlin/no/nav/syfo/application/metrics/MetricRegister.kt
+++ b/src/main/kotlin/no/nav/syfo/application/metrics/MetricRegister.kt
@@ -48,6 +48,12 @@ val SENDT_MELDING: Counter = Counter.build()
     .help("Antall sendte meldinger")
     .register()
 
+val UTSATT_MELDING: Counter = Counter.build()
+    .namespace(METRICS_NS)
+    .name("utsatt_melding_counter")
+    .help("Antall utsatte stansmeldinger")
+    .register()
+
 val SENDT_MAKSDATOMELDING: Counter = Counter.build()
     .namespace(METRICS_NS)
     .name("sendt_maksdato_counter")

--- a/src/main/kotlin/no/nav/syfo/model/PlanlagtMeldingDbModel.kt
+++ b/src/main/kotlin/no/nav/syfo/model/PlanlagtMeldingDbModel.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 const val BREV_4_UKER_TYPE = "4UKER"
 const val AKTIVITETSKRAV_8_UKER_TYPE = "8UKER"
 const val BREV_39_UKER_TYPE = "39UKER"
+const val STANS_TYPE = "STANS"
 
 data class PlanlagtMeldingDbModel(
     val id: UUID,

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
 import no.nav.syfo.model.BREV_4_UKER_TYPE
 import no.nav.syfo.model.PlanlagtMeldingDbModel
+import no.nav.syfo.model.STANS_TYPE
 import org.amshove.kluent.shouldEqual
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -86,6 +87,25 @@ object ArenaMeldingServiceTest : Spek({
         brev39Ukersmelding.n2830.versjon shouldEqual "015"
         brev39Ukersmelding.n2830.meldingsdata shouldEqual "02052020                                                                                  " // lengde 90
         brev39Ukersmelding.n2840.taglinje shouldEqual "SP: 39 ukersbrevet er dannet. Brevet sendes fra Arena (via denne hendelsen).    " // lengde 80
+    }
+
+    describe("Test av oppretting av stansmelding") {
+        val now = OffsetDateTime.of(LocalDate.of(2020, 7, 2).atTime(15, 20), ZoneOffset.UTC)
+        val planlagtMeldingDbModel = PlanlagtMeldingDbModel(
+            id = UUID.randomUUID(),
+            fnr = "12345678910",
+            startdato = LocalDate.of(2020, 5, 2),
+            type = STANS_TYPE,
+            opprettet = OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(8),
+            sendes = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10)
+        )
+
+        val stansmelding = arenaMeldingService.tilStansmelding(planlagtMeldingDbModel, now)
+
+        stansmelding.k278M810.dato shouldEqual "02072020"
+        stansmelding.k278M810.klokke shouldEqual "152000"
+        stansmelding.k278M810.fnr shouldEqual "12345678910"
+        stansmelding.k278M830.startdato shouldEqual "02052020"
     }
 
     describe("Test av datoformattering") {

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/arenamodel/StansmeldingTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/arenamodel/StansmeldingTest.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.aktivermelding.arenamodel
+
+import org.amshove.kluent.shouldEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object StansmeldingTest : Spek({
+    val k278M810 = K278M810Stans(
+        dato = "19062020",
+        klokke = "235157",
+        fnr = "12345678910"
+    )
+    val k278M830 = K278M830Stans(
+        startdato = "28052020"
+    )
+
+    val maksdatoMelding = Stansmelding(
+        k278M810 = k278M810,
+        k278M815 = K278M815Stans(),
+        k278M830 = k278M830,
+        k278M840 = K278M840Stans()
+    )
+
+    describe("Stansmelding får riktig tekstverdi") {
+        it("K278M810 får riktig tekstverdi") {
+            val k278M810SomTekst = k278M810.tilTekst()
+
+            k278M810SomTekst shouldEqual "K278M810SENDMELDINGSPEIL        0048219062020235157    12345678910  SPO "
+        }
+        it("K278M815 får riktig tekstverdi") {
+            val k278M815SomTekst = K278M815Stans().tilTekst()
+
+            k278M815SomTekst shouldEqual "K278M81500001                                                                                                                                                                                            " // lengde 201
+        }
+        it("K278M830 får riktig tekstverdi") {
+            val k278M830SomTekst = k278M830.tilTekst()
+
+            k278M830SomTekst shouldEqual "K278M83000001M-SPUB-1  00528052020AAAVSLUTTET                                                                       " // lengde 116
+        }
+        it("K278M840 får riktig tekstverdi") {
+            val k278M840SomTekst = K278M840Stans().tilTekst()
+
+            k278M840SomTekst shouldEqual "K278M84000001SP: SP sykepenger er stanset                                                    " // lengde 93
+        }
+        it("Maksdatomelding får riktig tekstverdi") {
+            val maksdatoMqMelding = maksdatoMelding.tilMqMelding()
+
+            maksdatoMqMelding shouldEqual "K278M810SENDMELDINGSPEIL        0048219062020235157    12345678910  SPO " +
+                    "K278M81500001                                                                                                                                                                                            " +
+                    "K278M83000001M-SPUB-1  00528052020AAAVSLUTTET                                                                       " +
+                    "K278M84000001SP: SP sykepenger er stanset                                                    " // lengde 482
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/lagrevedtak/LagreUtbetaltEventOgPlanlagtMeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/lagrevedtak/LagreUtbetaltEventOgPlanlagtMeldingServiceTest.kt
@@ -7,11 +7,14 @@ import java.util.UUID
 import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
 import no.nav.syfo.model.BREV_4_UKER_TYPE
+import no.nav.syfo.model.STANS_TYPE
 import no.nav.syfo.testutil.TestDB
 import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.hentPlanlagtMelding
 import no.nav.syfo.testutil.hentUtbetaltEvent
 import no.nav.syfo.testutil.lagUtbetaltEvent
+import no.nav.syfo.testutil.lagrePlanlagtMelding
+import no.nav.syfo.testutil.opprettPlanlagtMelding
 import org.amshove.kluent.shouldEqual
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -33,18 +36,20 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
 
     describe("Test av lagring av vedtaksinfo og planlagte meldinger") {
         val startdato = LocalDate.of(2020, 6, 1)
-        it("Lagrer vedtak og planlagt melding 8 uker for nytt tilfelle") {
-            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr")
+        val tom = LocalDate.of(2020, 7, 15)
+        it("Lagrer vedtak, stansmelding og planlagt melding 4, 8, 39 uker for nytt tilfelle") {
+            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
 
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
 
             val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
             val utbetaltEventFraDbListe = testDb.connection.hentUtbetaltEvent("fnr", startdato)
-            planlagtMeldingFraDbListe.size shouldEqual 3
+            planlagtMeldingFraDbListe.size shouldEqual 4
             utbetaltEventFraDbListe.size shouldEqual 1
             val planlagtMelding4uker = planlagtMeldingFraDbListe.find { it.type == BREV_4_UKER_TYPE }
             val planlagtMelding8uker = planlagtMeldingFraDbListe.find { it.type == AKTIVITETSKRAV_8_UKER_TYPE }
             val planlagtMelding39uker = planlagtMeldingFraDbListe.find { it.type == BREV_39_UKER_TYPE }
+            val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
             val utbetaltEventFraDb = utbetaltEventFraDbListe.first()
 
             planlagtMelding4uker?.fnr shouldEqual "fnr"
@@ -68,19 +73,39 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
             planlagtMelding39uker?.sendt shouldEqual null
             planlagtMelding39uker?.avbrutt shouldEqual null
 
+            planlagtStansmelding?.fnr shouldEqual "fnr"
+            planlagtStansmelding?.startdato shouldEqual startdato
+            planlagtStansmelding?.type shouldEqual STANS_TYPE
+            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.sendt shouldEqual null
+            planlagtStansmelding?.avbrutt shouldEqual null
+
             utbetaltEventFraDb shouldEqual utbetaltEvent
         }
-        it("Lagrer kun vedtak, ikke melding, hvis planlagt melding finnes for syketilfellet fra før") {
-            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr")
-            val nesteUtbetaltEvent = lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr")
+        it("Lagrer kun vedtak og oppdaterer stansmelding, hvis planlagte meldinger finnes for syketilfellet fra før") {
+            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
+            val nesteUtbetaltEvent = lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.plusWeeks(1))
 
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(nesteUtbetaltEvent)
 
             val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
             val utbetaltEventFraDbListe = testDb.connection.hentUtbetaltEvent("fnr", startdato)
-            planlagtMeldingFraDbListe.size shouldEqual 3
+            planlagtMeldingFraDbListe.size shouldEqual 4
             utbetaltEventFraDbListe.size shouldEqual 2
+            val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
+            planlagtStansmelding?.sendes shouldEqual tom.plusWeeks(1).plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+        }
+        it("Oppretter stansmelding hvis det ikke finnes fra før") {
+            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
+            testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = UUID.randomUUID(), fnr = "fnr", startdato = startdato))
+
+            lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
+
+            val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
+            planlagtMeldingFraDbListe.size shouldEqual 2
+            val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
+            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
         }
         it("Lagrer vedtak og melding hvis planlagt melding finnes for tidligere syketilfelle for samme bruker") {
             val nesteStartdato = startdato.plusMonths(1)
@@ -94,8 +119,8 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
             val nestePlanlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", nesteStartdato)
             val utbetaltEventFraDbListe = testDb.connection.hentUtbetaltEvent("fnr", startdato)
             val nesteUtbetaltEventFraDbListe = testDb.connection.hentUtbetaltEvent("fnr", nesteStartdato)
-            planlagtMeldingFraDbListe.size shouldEqual 3
-            nestePlanlagtMeldingFraDbListe.size shouldEqual 3
+            planlagtMeldingFraDbListe.size shouldEqual 4
+            nestePlanlagtMeldingFraDbListe.size shouldEqual 4
             utbetaltEventFraDbListe.size shouldEqual 1
             nesteUtbetaltEventFraDbListe.size shouldEqual 1
         }


### PR DESCRIPTION
Vi må sende stansmeldinger til Arena for å avslutte oppfølgingstilfeller når bruker er friskmeldt. 

Når vi mottar en utbetalingsmelding oppretter vi planlagt stansmelding med utsendingstidspunkt satt til siste dag utbetalingen gjelder for pluss 17 dager. Hvis stansmeldingen finnes fra før oppdaterer vi utsendelsestidspunktet. 

Når en stansmelding plukkes opp fordi utsendelsestidspunkt er passert uten at meldingen er sendt eller avbrutt skjer følgende: 
1. Hvis det har dukket opp et nyere syketilfelle for brukeren avbryter vi stansmeldingen. 
2. Hvis bruker fortsatt er sykmeldt oppdaterer vi utsendingstidspunkt for stansmeldingen til å være siste tom-dato i sykmeldingen pluss 17 dager. 
3. Hvis bruker ikke lenger er sykmeldt sender vi stansmeldingen til Arena. 

Jeg kommer til å legge på en featuretoggle slik at vi ikke sender meldinger for alle brukere med en gang. Det kommer i en ny commit så fort jeg har fått testet litt i dev :) 