### PR TITLE
sender stansmelding kun hvis sykmeldt mer enn 4 uker

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
@@ -19,6 +19,7 @@ import no.nav.syfo.application.metrics.IKKE_FUNNET_MELDING
 import no.nav.syfo.application.metrics.MOTTATT_AKTIVERMELDING
 import no.nav.syfo.application.metrics.SENDT_MELDING
 import no.nav.syfo.application.metrics.UTSATT_MELDING
+import no.nav.syfo.db.fireukersmeldingErSendt
 import no.nav.syfo.log
 import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
@@ -82,11 +83,11 @@ class AktiverMeldingService(
     private suspend fun sendEllerUtsettStansmelding(planlagtMelding: PlanlagtMeldingDbModel) {
         val sykmeldtTom = smregisterClient.erSykmeldtTilOgMed(planlagtMelding.fnr, planlagtMelding.id)
         if (sykmeldtTom == null) {
-            if (trefferAldersfilter(planlagtMelding.fnr, Filter.ETTER1995)) {
+            if (trefferAldersfilter(planlagtMelding.fnr, Filter.ETTER1995) && database.fireukersmeldingErSendt(planlagtMelding.fnr, planlagtMelding.startdato)) {
                 log.info("Bruker er ikke lenger sykmeldt, aktiverer stansmelding ${planlagtMelding.id}")
                 sendTilArena(planlagtMelding)
             } else {
-                log.info("Bruker er ikke lenger sykmeldt, men treffer ikke filter, stansmelding ${planlagtMelding.id}")
+                log.info("Bruker er ikke lenger sykmeldt, men var sykmeldt mindre enn 4 uker/treffer ikke filter, stansmelding ${planlagtMelding.id}")
                 avbrytMelding(AktiverMelding(planlagtMelding.id))
             }
         } else {

--- a/src/main/kotlin/no/nav/syfo/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/db/DbQueries.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.lagrevedtak.maksdato
+package no.nav.syfo.db
 
 import java.sql.Connection
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/syfo/lagrevedtak/maksdato/MaksdatoService.kt
+++ b/src/main/kotlin/no/nav/syfo/lagrevedtak/maksdato/MaksdatoService.kt
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter
 import no.nav.syfo.aktivermelding.mq.ArenaMqProducer
 import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.metrics.SENDT_MAKSDATOMELDING
+import no.nav.syfo.db.fireukersmeldingErSendt
 import no.nav.syfo.lagrevedtak.UtbetaltEvent
 import no.nav.syfo.log
 


### PR DESCRIPTION
Brukere som er sykmeldt i mindre enn fire uker havner normalt ikke i Arena, så da er det jo unødvendig å stoppe sykefraværstilfeller som aldri blir opprettet i Arena :D 