### PR TITLE
Utsettelse

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingService.kt
@@ -2,15 +2,20 @@ package no.nav.syfo.aktivermelding
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.util.KtorExperimentalAPI
+import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
 import kotlinx.coroutines.delay
+import no.nav.syfo.aktivermelding.db.finnAktivStansmelding
 import no.nav.syfo.aktivermelding.db.finnAvbruttAktivitetskravmelding
 import no.nav.syfo.aktivermelding.db.resendAvbruttMelding
 import no.nav.syfo.aktivermelding.db.sendPlanlagtMelding
+import no.nav.syfo.aktivermelding.db.utsettPlanlagtMelding
 import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.metrics.SENDT_AVBRUTT_MELDING
+import no.nav.syfo.application.metrics.UTSATT_MELDING
 import no.nav.syfo.client.SyfoSyketilfelleClient
 import no.nav.syfo.log
 import no.nav.syfo.model.Periode
@@ -30,19 +35,34 @@ class MottattSykmeldingService(
         behandleMottattSykmelding(receivedSykmelding)
     }
 
+    suspend fun behandleMottattSykmelding(receivedSykmelding: ReceivedSykmelding) {
+        val sykmeldingId = receivedSykmelding.sykmelding.id
+
+        val aktiveStansmeldinger = database.finnAktivStansmelding(receivedSykmelding.personNrPasient)
+        val avbrutteAktivitetskravMeldinger = database.finnAvbruttAktivitetskravmelding(receivedSykmelding.personNrPasient)
+
+        if (aktiveStansmeldinger.isEmpty() && avbrutteAktivitetskravMeldinger.isEmpty()) {
+            log.info("Fant ingen relevante planlagte meldinger knyttet til sykmeldingid $sykmeldingId")
+            return
+        }
+        if (skalVenteLitt) {
+            delay(5000) // Venter slik at sykmeldingen kommer inn i syfosyketilfelle...
+        }
+        val startdato = syfoSyketilfelleClient.finnStartdato(receivedSykmelding.sykmelding.pasientAktoerId, sykmeldingId, UUID.fromString(sykmeldingId))
+
+        sendAvbruttAktivitetskravmelding(receivedSykmelding, avbrutteAktivitetskravMeldinger.firstOrNull { it.startdato == startdato })
+        utsettStansmelding(receivedSykmelding, aktiveStansmeldinger.firstOrNull { it.startdato == startdato })
+    }
+
     // En melding avbrytes kun hvis bruker enten er frisk eller har gradert sykmelding ved 8 uker. Derfor blir det
     // riktig å sende melding hvis det kommer inn en ny sykmelding som ikke er gradert hvis det finnes avbrutt melding
     // for samme sykeforløp (samme startdato).
-    suspend fun behandleMottattSykmelding(receivedSykmelding: ReceivedSykmelding) {
+    fun sendAvbruttAktivitetskravmelding(receivedSykmelding: ReceivedSykmelding, avbruttMelding: PlanlagtMeldingDbModel?) {
         val sykmeldingId = receivedSykmelding.sykmelding.id
         if (inneholderGradertPeriode(receivedSykmelding.sykmelding.perioder)) {
             log.info("Ignorerer gradert sykmelding med id {}", sykmeldingId)
             return
         }
-        val avbruttMelding = finnAvbruttMeldingForSykeforloep(
-            fnr = receivedSykmelding.personNrPasient,
-            aktorId = receivedSykmelding.sykmelding.pasientAktoerId,
-            sykmeldingId = sykmeldingId)
         if (avbruttMelding == null) {
             log.info("Fant ingen matchende avbrutte meldinger, ignorerer sykmelding med id {}", sykmeldingId)
         } else {
@@ -54,19 +74,25 @@ class MottattSykmeldingService(
         }
     }
 
+    fun utsettStansmelding(receivedSykmelding: ReceivedSykmelding, stansmelding: PlanlagtMeldingDbModel?) {
+        val sykmeldingId = receivedSykmelding.sykmelding.id
+        if (stansmelding == null) {
+            log.info("Fant ingen matchende stansmeldinger, ignorerer sykmelding med id {}", sykmeldingId)
+        } else {
+            val oppdatertSendes = finnSisteTom(receivedSykmelding.sykmelding.perioder).plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            if (oppdatertSendes.isAfter(stansmelding.sendes)) {
+                log.info("Mottatt sykmelding med nyeste tomdato senere en utsendingstidspunkt, utsetter stansmelding ${stansmelding.id}")
+                database.utsettPlanlagtMelding(stansmelding.id, oppdatertSendes)
+                UTSATT_MELDING.inc()
+            }
+        }
+    }
+
     fun inneholderGradertPeriode(perioder: List<Periode>): Boolean {
         return perioder.firstOrNull { it.gradert != null }?.gradert != null
     }
 
-    suspend fun finnAvbruttMeldingForSykeforloep(fnr: String, aktorId: String, sykmeldingId: String): PlanlagtMeldingDbModel? {
-        val avbrutteAktivitetskravMeldinger = database.finnAvbruttAktivitetskravmelding(fnr)
-        if (avbrutteAktivitetskravMeldinger.isEmpty()) {
-            return null
-        }
-        if (skalVenteLitt) {
-            delay(5000) // Venter slik at sykmeldingen kommer inn i syfosyketilfelle...
-        }
-        val startdato = syfoSyketilfelleClient.finnStartdato(aktorId, sykmeldingId, UUID.fromString(sykmeldingId))
-        return avbrutteAktivitetskravMeldinger.firstOrNull { it.startdato == startdato }
+    private fun finnSisteTom(perioder: List<Periode>): LocalDate {
+        return perioder.maxBy { it.tom }?.tom ?: throw IllegalStateException("Skal ikke kunne ha periode uten tom")
     }
 }

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -56,6 +56,12 @@ fun DatabaseInterface.finnAvbruttAktivitetskravmelding(fnr: String): List<Planla
     }
 }
 
+fun DatabaseInterface.finnAktivStansmelding(fnr: String): List<PlanlagtMeldingDbModel> {
+    connection.use { connection ->
+        return connection.finnAktiveStansmeldinger(fnr)
+    }
+}
+
 private fun Connection.hentPlanlagtMelding(id: UUID): PlanlagtMeldingDbModel? =
     this.prepareStatement(
         """
@@ -124,6 +130,16 @@ private fun Connection.finnAvbruttAktivitetskravmelding(fnr: String): List<Planl
     this.prepareStatement(
         """
             SELECT * FROM planlagt_melding WHERE fnr=? AND type='8UKER' AND avbrutt is not null;
+            """
+    ).use {
+        it.setString(1, fnr)
+        it.executeQuery().toList { toPlanlagtMeldingDbModel() }
+    }
+
+private fun Connection.finnAktiveStansmeldinger(fnr: String): List<PlanlagtMeldingDbModel> =
+    this.prepareStatement(
+        """
+            SELECT * FROM planlagt_melding WHERE fnr=? AND type='STANS' AND sendt is null AND avbrutt is null;
             """
     ).use {
         it.setString(1, fnr)

--- a/src/main/kotlin/no/nav/syfo/lagrevedtak/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/lagrevedtak/db/DbQueries.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.lagrevedtak.db
 
 import java.sql.Connection
-import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -12,6 +11,7 @@ import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.db.toList
 import no.nav.syfo.lagrevedtak.UtbetaltEvent
 import no.nav.syfo.model.PlanlagtMeldingDbModel
+import no.nav.syfo.model.toPlanlagtMeldingDbModel
 import no.nav.syfo.objectMapper
 import org.postgresql.util.PGobject
 
@@ -20,14 +20,18 @@ fun DatabaseInterface.lagreUtbetaltEventOgOppdaterStansmelding(
     planlagtStansmelding: PlanlagtMeldingDbModel
 ) {
     connection.use { connection ->
-        val meldingId = connection.hentPlanlagtStansmelding(planlagtStansmelding.fnr, planlagtStansmelding.startdato)
-        if (meldingId == null) {
+        val melding = connection.hentPlanlagtStansmelding(planlagtStansmelding.fnr, planlagtStansmelding.startdato)
+        if (melding == null) {
             connection.lagrePlanlagtMelding(planlagtStansmelding)
         } else {
-            connection.oppdaterStansmelding(
-                meldingId,
-                utbetaltEvent.tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
-            )
+            val oppdatertSendes = utbetaltEvent.tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            if (oppdatertSendes.isAfter(melding.sendes)) {
+                connection.oppdaterStansmelding(
+                    melding.id,
+                    utbetaltEvent.tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault())
+                        .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+                )
+            }
         }
         connection.lagreUtbetaltEvent(utbetaltEvent)
         connection.commit()
@@ -96,19 +100,16 @@ private fun Connection.lagreUtbetaltEvent(utbetaltEvent: UtbetaltEvent) {
     }
 }
 
-private fun Connection.hentPlanlagtStansmelding(fnr: String, startdato: LocalDate): UUID? =
+private fun Connection.hentPlanlagtStansmelding(fnr: String, startdato: LocalDate): PlanlagtMeldingDbModel? =
     this.prepareStatement(
         """
-            SELECT id FROM planlagt_melding WHERE fnr=? AND startdato=? AND type='STANS' AND sendt is null AND avbrutt is null;
+            SELECT * FROM planlagt_melding WHERE fnr=? AND startdato=? AND type='STANS' AND sendt is null AND avbrutt is null;
             """
     ).use {
         it.setString(1, fnr)
         it.setObject(2, startdato)
-        it.executeQuery().toList { toUuid() }.firstOrNull()
+        it.executeQuery().toList { toPlanlagtMeldingDbModel() }.firstOrNull()
     }
-
-private fun ResultSet.toUuid(): UUID =
-    getObject("id", UUID::class.java)
 
 private fun Connection.oppdaterStansmelding(id: UUID, sendes: OffsetDateTime) =
     this.prepareStatement(

--- a/src/main/kotlin/no/nav/syfo/lagrevedtak/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/lagrevedtak/db/DbQueries.kt
@@ -114,7 +114,7 @@ private fun Connection.hentPlanlagtStansmelding(fnr: String, startdato: LocalDat
 private fun Connection.oppdaterStansmelding(id: UUID, sendes: OffsetDateTime) =
     this.prepareStatement(
         """
-            UPDATE planlagt_melding SET sendes=? WHERE id=?;
+            UPDATE planlagt_melding SET sendes=?, avbrutt=null  WHERE id=?;
             """
     ).use {
         it.setTimestamp(1, Timestamp.from(sendes.toInstant()))

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingServiceTest.kt
@@ -7,17 +7,19 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aktivermelding.db.hentPlanlagtMelding
 import no.nav.syfo.aktivermelding.db.sendPlanlagtMelding
 import no.nav.syfo.client.SyfoSyketilfelleClient
+import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.AktivitetIkkeMulig
 import no.nav.syfo.model.Gradert
 import no.nav.syfo.model.MedisinskArsak
 import no.nav.syfo.model.Periode
-import no.nav.syfo.model.PlanlagtMeldingDbModel
+import no.nav.syfo.model.STANS_TYPE
 import no.nav.syfo.testutil.TestDB
 import no.nav.syfo.testutil.dropData
 import no.nav.syfo.testutil.hentPlanlagtMelding
@@ -37,12 +39,17 @@ object MottattSykmeldingServiceTest : Spek({
     val idAvbrutt = UUID.randomUUID()
     val idAvbrutt2 = UUID.randomUUID()
     val idIkkeAvbrutt = UUID.randomUUID()
+    val idAvbruttStansmelding = UUID.randomUUID()
+    val idStansmelding = UUID.randomUUID()
+    val utsendingStansmelding = OffsetDateTime.now(ZoneOffset.UTC).plusDays(3)
 
     beforeEachTest {
         clearAllMocks()
-        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idAvbrutt, fnr = "12345678910", startdato = LocalDate.of(2020, 3, 25), avbrutt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(3)))
-        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idAvbrutt2, fnr = "12345678910", startdato = LocalDate.of(2020, 1, 25), avbrutt = OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(3)))
-        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idIkkeAvbrutt, fnr = "01987654321", startdato = LocalDate.of(2020, 3, 25)))
+        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idAvbrutt, type = AKTIVITETSKRAV_8_UKER_TYPE, fnr = "12345678910", startdato = LocalDate.of(2020, 3, 25), avbrutt = OffsetDateTime.now(ZoneOffset.UTC).minusDays(3)))
+        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idStansmelding, type = STANS_TYPE, fnr = "12345678910", startdato = LocalDate.of(2020, 3, 25), sendes = utsendingStansmelding))
+        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idAvbrutt2, type = AKTIVITETSKRAV_8_UKER_TYPE, fnr = "12345678910", startdato = LocalDate.of(2020, 1, 25), avbrutt = OffsetDateTime.now(ZoneOffset.UTC).minusWeeks(3)))
+        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idIkkeAvbrutt, type = AKTIVITETSKRAV_8_UKER_TYPE, fnr = "01987654321", startdato = LocalDate.of(2020, 3, 25)))
+        testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = idAvbruttStansmelding, type = STANS_TYPE, fnr = "01987654321", startdato = LocalDate.of(2020, 3, 25), avbrutt = OffsetDateTime.now(ZoneOffset.UTC)))
     }
 
     afterEachTest {
@@ -54,7 +61,30 @@ object MottattSykmeldingServiceTest : Spek({
     }
 
     describe("Test av behandling av mottatt sykmelding") {
-        it("Ignorerer sykmelding med gradert periode") {
+        it("Ignorerer sykmelding uten tilhørende planlagte meldinger") {
+            val receivedSykmelding = opprettReceivedSykmelding(
+                "01987654321", listOf(
+                    Periode(
+                        fom = LocalDate.now(),
+                        tom = LocalDate.now().plusWeeks(3),
+                        aktivitetIkkeMulig = AktivitetIkkeMulig(medisinskArsak = MedisinskArsak(null, emptyList()), arbeidsrelatertArsak = null),
+                        avventendeInnspillTilArbeidsgiver = null,
+                        behandlingsdager = null,
+                        gradert = null,
+                        reisetilskudd = false
+                    )
+                )
+            )
+
+            runBlocking {
+                mottattSykmeldingService.behandleMottattSykmelding(receivedSykmelding)
+            }
+
+            coVerify(exactly = 0) { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
+            coVerify(exactly = 0) { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
+        }
+        it("Sender ikke avbrutt aktivitetskravmelding for gradert sykmelding, utsetter stansmelding") {
+            coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 3, 25)
             val receivedSykmelding = opprettReceivedSykmelding(
                 "12345678910", listOf(
                     Periode(
@@ -73,8 +103,10 @@ object MottattSykmeldingServiceTest : Spek({
                 mottattSykmeldingService.behandleMottattSykmelding(receivedSykmelding)
             }
 
-            coVerify(exactly = 0) { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
+            coVerify { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
             coVerify(exactly = 0) { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
+            val stansmelding = testDb.hentPlanlagtMelding(idStansmelding)
+            stansmelding?.sendes shouldEqual LocalDate.now().plusWeeks(3).plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
         }
         it("Ignorerer sykmelding som ikke har avbrutt melding for samme sykeforløp") {
             coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 6, 25)
@@ -98,8 +130,35 @@ object MottattSykmeldingServiceTest : Spek({
 
             coVerify { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
             coVerify(exactly = 0) { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
+            val stansmelding = testDb.hentPlanlagtMelding(idStansmelding)
+            stansmelding?.sendes shouldEqual utsendingStansmelding
         }
-        it("Oppdaterer og sender tidligere avbrutt melding for samme sykeforløp hvis sykmelding ikke er gradert") {
+        it("Oppdaterer ikke stansmelding hvis nytt utsendingstidspunkt er tidligere enn det som er satt") {
+            coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 3, 25)
+            val receivedSykmelding = opprettReceivedSykmelding(
+                "12345678910", listOf(
+                    Periode(
+                        fom = LocalDate.now().minusWeeks(3),
+                        tom = LocalDate.now().minusWeeks(2),
+                        aktivitetIkkeMulig = AktivitetIkkeMulig(medisinskArsak = MedisinskArsak(null, emptyList()), arbeidsrelatertArsak = null),
+                        avventendeInnspillTilArbeidsgiver = null,
+                        behandlingsdager = null,
+                        gradert = null,
+                        reisetilskudd = false
+                    )
+                )
+            )
+
+            runBlocking {
+                mottattSykmeldingService.behandleMottattSykmelding(receivedSykmelding)
+            }
+
+            coVerify { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
+            coVerify { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
+            val stansmelding = testDb.hentPlanlagtMelding(idStansmelding)
+            stansmelding?.sendes shouldEqual utsendingStansmelding
+        }
+        it("Oppdaterer og sender tidligere avbrutt melding for samme sykeforløp hvis sykmelding ikke er gradert, utsetter stansmelding") {
             coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 3, 25)
             val receivedSykmelding = opprettReceivedSykmelding(
                 "12345678910", listOf(
@@ -122,10 +181,13 @@ object MottattSykmeldingServiceTest : Spek({
             coVerify { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
             coVerify { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
             val meldinger = testDb.connection.hentPlanlagtMelding("12345678910", LocalDate.of(2020, 3, 25))
-            meldinger.size shouldEqual 1
-            meldinger[0].avbrutt shouldEqual null
+            meldinger.size shouldEqual 2
+            val planlagtMelding8uker = meldinger.find { it.type == AKTIVITETSKRAV_8_UKER_TYPE }
+            val planlagtStansmelding = meldinger.find { it.type == STANS_TYPE }
+            planlagtMelding8uker!!.avbrutt shouldEqual null
+            planlagtStansmelding?.sendes shouldEqual LocalDate.now().plusWeeks(3).plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
         }
-        it("Skal ikke sende ny melding hvis melding er sent før") {
+        it("Skal ikke sende ny 8-ukersmelding hvis melding er sent før") {
             coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 3, 25)
             val receivedSykmelding = opprettReceivedSykmelding(
                 "12345678910", listOf(
@@ -150,48 +212,9 @@ object MottattSykmeldingServiceTest : Spek({
             coVerify(exactly = 2) { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) }
             coVerify(exactly = 1) { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) }
             val meldinger = testDb.connection.hentPlanlagtMelding("12345678910", LocalDate.of(2020, 3, 25))
-            meldinger.size shouldEqual 1
-            meldinger[0].avbrutt shouldEqual null
-        }
-    }
-
-    describe("Tester for å finne avbrutt melding") {
-        it("Returnerer null hvis det ikke finnes avbrutt melding for fnr") {
-            var melding: PlanlagtMeldingDbModel? = null
-            runBlocking {
-                melding = mottattSykmeldingService.finnAvbruttMeldingForSykeforloep("01987654321", "aktorId", UUID.randomUUID().toString())
-            }
-
-            melding shouldEqual null
-        }
-        it("Returnerer null hvis det finnes avbrutt melding for fnr for annen startdato") {
-            coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 6, 25)
-
-            var melding: PlanlagtMeldingDbModel? = null
-            runBlocking {
-                melding = mottattSykmeldingService.finnAvbruttMeldingForSykeforloep("12345678910", "aktorId", UUID.randomUUID().toString())
-            }
-
-            melding shouldEqual null
-        }
-        it("Returnerer melding hvis det finnes avbrutt melding for fnr og samme startdato") {
-            coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } returns LocalDate.of(2020, 3, 25)
-
-            var melding: PlanlagtMeldingDbModel? = null
-            runBlocking {
-                melding = mottattSykmeldingService.finnAvbruttMeldingForSykeforloep("12345678910", "aktorId", UUID.randomUUID().toString())
-            }
-
-            melding?.id shouldEqual idAvbrutt
-        }
-        it("Kaster feil hvis sykeforløp ikke finnes (syfosyketilfelle ikke oppdatert)") {
-            coEvery { syfoSyketilfelleClient.finnStartdato(any(), any(), any()) } throws RuntimeException("Fant ikke sykeforløp")
-
-            assertFailsWith<RuntimeException> {
-                runBlocking {
-                    mottattSykmeldingService.finnAvbruttMeldingForSykeforloep("12345678910", "aktorId", UUID.randomUUID().toString())
-                }
-            }
+            meldinger.size shouldEqual 2
+            val planlagtMelding8uker = meldinger.find { it.type == AKTIVITETSKRAV_8_UKER_TYPE }
+            planlagtMelding8uker!!.avbrutt shouldEqual null
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/lagrevedtak/LagreUtbetaltEventOgPlanlagtMeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/lagrevedtak/LagreUtbetaltEventOgPlanlagtMeldingServiceTest.kt
@@ -4,9 +4,11 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
+import no.nav.syfo.lagrevedtak.db.lagreUtbetaltEventOgPlanlagtMelding
 import no.nav.syfo.model.AKTIVITETSKRAV_8_UKER_TYPE
 import no.nav.syfo.model.BREV_39_UKER_TYPE
 import no.nav.syfo.model.BREV_4_UKER_TYPE
+import no.nav.syfo.model.PlanlagtMeldingDbModel
 import no.nav.syfo.model.STANS_TYPE
 import no.nav.syfo.testutil.TestDB
 import no.nav.syfo.testutil.dropData
@@ -55,28 +57,32 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
             planlagtMelding4uker?.fnr shouldEqual "fnr"
             planlagtMelding4uker?.startdato shouldEqual startdato
             planlagtMelding4uker?.type shouldEqual BREV_4_UKER_TYPE
-            planlagtMelding4uker?.sendes shouldEqual startdato.plusWeeks(4).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtMelding4uker?.sendes shouldEqual startdato.plusWeeks(4).atStartOfDay()
+                .atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
             planlagtMelding4uker?.sendt shouldEqual null
             planlagtMelding4uker?.avbrutt shouldEqual null
 
             planlagtMelding8uker?.fnr shouldEqual "fnr"
             planlagtMelding8uker?.startdato shouldEqual startdato
             planlagtMelding8uker?.type shouldEqual AKTIVITETSKRAV_8_UKER_TYPE
-            planlagtMelding8uker?.sendes shouldEqual startdato.plusWeeks(8).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtMelding8uker?.sendes shouldEqual startdato.plusWeeks(8).atStartOfDay()
+                .atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
             planlagtMelding8uker?.sendt shouldEqual null
             planlagtMelding8uker?.avbrutt shouldEqual null
 
             planlagtMelding39uker?.fnr shouldEqual "fnr"
             planlagtMelding39uker?.startdato shouldEqual startdato
             planlagtMelding39uker?.type shouldEqual BREV_39_UKER_TYPE
-            planlagtMelding39uker?.sendes shouldEqual startdato.plusWeeks(39).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtMelding39uker?.sendes shouldEqual startdato.plusWeeks(39).atStartOfDay()
+                .atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
             planlagtMelding39uker?.sendt shouldEqual null
             planlagtMelding39uker?.avbrutt shouldEqual null
 
             planlagtStansmelding?.fnr shouldEqual "fnr"
             planlagtStansmelding?.startdato shouldEqual startdato
             planlagtStansmelding?.type shouldEqual STANS_TYPE
-            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault())
+                .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
             planlagtStansmelding?.sendt shouldEqual null
             planlagtStansmelding?.avbrutt shouldEqual null
 
@@ -84,7 +90,8 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
         }
         it("Lagrer kun vedtak og oppdaterer stansmelding, hvis planlagte meldinger finnes for syketilfellet fra før") {
             val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
-            val nesteUtbetaltEvent = lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.plusWeeks(1))
+            val nesteUtbetaltEvent =
+                lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.plusWeeks(1))
 
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(nesteUtbetaltEvent)
@@ -94,11 +101,13 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
             planlagtMeldingFraDbListe.size shouldEqual 4
             utbetaltEventFraDbListe.size shouldEqual 2
             val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
-            planlagtStansmelding?.sendes shouldEqual tom.plusWeeks(1).plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.sendes shouldEqual tom.plusWeeks(1).plusDays(17).atStartOfDay()
+                .atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
         }
         it("Oppdaterer ikke stansmelding hvis nytt utsendingstidspunkt er tidligere enn det forrige") {
             val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
-            val nesteUtbetaltEvent = lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.minusWeeks(1))
+            val nesteUtbetaltEvent =
+                lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.minusWeeks(1))
 
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(nesteUtbetaltEvent)
@@ -106,18 +115,55 @@ object LagreUtbetaltEventOgPlanlagtMeldingServiceTest : Spek({
             val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
             planlagtMeldingFraDbListe.size shouldEqual 4
             val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
-            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault())
+                .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+        }
+        it("Gjenåpner stansmelding hvis stansmelding for samme sykefravær var avbrutt") {
+            val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
+            val nesteUtbetaltEvent = lagUtbetaltEvent(UUID.randomUUID(), UUID.randomUUID(), startdato, "fnr", tom.plusWeeks(1))
+            testDb.lagreUtbetaltEventOgPlanlagtMelding(
+                utbetaltEvent, listOf(
+                    PlanlagtMeldingDbModel(
+                        id = UUID.randomUUID(),
+                        fnr = "fnr",
+                        startdato = startdato,
+                        type = STANS_TYPE,
+                        opprettet = tom.minusWeeks(10).atStartOfDay().atZone(ZoneId.systemDefault())
+                            .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                        sendes = tom.minusWeeks(8).atStartOfDay().atZone(ZoneId.systemDefault())
+                            .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                        avbrutt = tom.minusWeeks(8).atStartOfDay().atZone(ZoneId.systemDefault())
+                            .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                        sendt = null
+                    )
+                )
+            )
+            lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(nesteUtbetaltEvent)
+
+            val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
+            planlagtMeldingFraDbListe.size shouldEqual 1
+            val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
+            planlagtStansmelding?.sendes shouldEqual tom.plusWeeks(1).plusDays(17).atStartOfDay()
+                .atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.avbrutt shouldEqual null
         }
         it("Oppretter stansmelding hvis det ikke finnes fra før") {
             val utbetaltEvent = lagUtbetaltEvent(utbetaltEventId, sykmeldingId, startdato, "fnr", tom)
-            testDb.connection.lagrePlanlagtMelding(opprettPlanlagtMelding(id = UUID.randomUUID(), fnr = "fnr", startdato = startdato))
+            testDb.connection.lagrePlanlagtMelding(
+                opprettPlanlagtMelding(
+                    id = UUID.randomUUID(),
+                    fnr = "fnr",
+                    startdato = startdato
+                )
+            )
 
             lagreUtbetaltEventOgPlanlagtMeldingService.lagreUtbetaltEventOgPlanlagtMelding(utbetaltEvent)
 
             val planlagtMeldingFraDbListe = testDb.connection.hentPlanlagtMelding("fnr", startdato)
             planlagtMeldingFraDbListe.size shouldEqual 2
             val planlagtStansmelding = planlagtMeldingFraDbListe.find { it.type == STANS_TYPE }
-            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtStansmelding?.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault())
+                .withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
         }
         it("Lagrer vedtak og melding hvis planlagt melding finnes for tidligere syketilfelle for samme bruker") {
             val nesteStartdato = startdato.plusMonths(1)


### PR DESCRIPTION
Hvis bruker mottar en ny sykmelding ønsker vi å utsette utsendingen av stansmelding (hvis den nye sykmeldingen sin tom-dato gir et senere utsendingstidspunkt enn vi har fra før). 

Jeg måtte omstrukturere litt i MottattSykmeldingService så vi ikke gjør flere kall enn nødvendig (vi kunne ha kuttet et databasekall til ved å hente både stansmeldinger og aktivitetskravmeldinger i samme spørring, men da tror jeg koden hadde blitt mindre lesbar, og det er jo innviklet nok som det er..). 