### PR TITLE
nyere sykefravær kan ha tidligere startdato også

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
@@ -8,7 +8,7 @@ import java.time.ZoneOffset
 import no.nav.syfo.Filter
 import no.nav.syfo.aktivermelding.client.SmregisterClient
 import no.nav.syfo.aktivermelding.db.avbrytPlanlagtMelding
-import no.nav.syfo.aktivermelding.db.finnesPlanlagtMeldingMedNyereStartdato
+import no.nav.syfo.aktivermelding.db.finnesNyerePlanlagtMeldingMedAnnenStartdato
 import no.nav.syfo.aktivermelding.db.hentPlanlagtMelding
 import no.nav.syfo.aktivermelding.db.sendPlanlagtMelding
 import no.nav.syfo.aktivermelding.db.utsettPlanlagtMelding
@@ -45,10 +45,10 @@ class AktiverMeldingService(
     suspend fun behandleAktiverMelding(aktiverMelding: AktiverMelding) {
         val planlagtMelding = database.hentPlanlagtMelding(aktiverMelding.id)
         if (planlagtMelding != null) {
-            val finnesPlanlagtMeldingMedNyereStartdato =
-                database.finnesPlanlagtMeldingMedNyereStartdato(planlagtMelding.fnr, planlagtMelding.startdato)
-            if (finnesPlanlagtMeldingMedNyereStartdato) {
-                log.info("Det finnes planlagte meldinger for sykefravær med nyere startdato, avbryter melding med id ${planlagtMelding.id}")
+            val finnesNyerePlanlagtMeldingMedAnnenStartdato =
+                database.finnesNyerePlanlagtMeldingMedAnnenStartdato(planlagtMelding.fnr, planlagtMelding.startdato, planlagtMelding.opprettet)
+            if (finnesNyerePlanlagtMeldingMedAnnenStartdato) {
+                log.info("Det finnes nyere planlagte meldinger for sykefravær med annen startdato, avbryter melding med id ${planlagtMelding.id}")
                 avbrytMelding(aktiverMelding)
             } else if (planlagtMelding.type == STANS_TYPE) {
                 sendEllerUtsettStansmelding(planlagtMelding)

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -16,9 +16,9 @@ fun DatabaseInterface.hentPlanlagtMelding(id: UUID): PlanlagtMeldingDbModel? {
     }
 }
 
-fun DatabaseInterface.finnesPlanlagtMeldingMedNyereStartdato(fnr: String, startdato: LocalDate): Boolean {
+fun DatabaseInterface.finnesNyerePlanlagtMeldingMedAnnenStartdato(fnr: String, startdato: LocalDate, opprettet: OffsetDateTime): Boolean {
     connection.use { connection ->
-        return connection.finnesPlanlagtMeldingMedNyereStartdato(fnr, startdato)
+        return connection.finnesNyerePlanlagtMeldingMedAnnenStartdato(fnr, startdato, opprettet)
     }
 }
 
@@ -72,14 +72,15 @@ private fun Connection.hentPlanlagtMelding(id: UUID): PlanlagtMeldingDbModel? =
         it.executeQuery().toList { toPlanlagtMeldingDbModel() }.firstOrNull()
     }
 
-private fun Connection.finnesPlanlagtMeldingMedNyereStartdato(fnr: String, startdato: LocalDate): Boolean =
+private fun Connection.finnesNyerePlanlagtMeldingMedAnnenStartdato(fnr: String, startdato: LocalDate, opprettet: OffsetDateTime): Boolean =
     this.prepareStatement(
         """
-            SELECT 1 FROM planlagt_melding WHERE fnr=? AND startdato>?;
+            SELECT 1 FROM planlagt_melding WHERE fnr=? AND startdato!=? AND opprettet>?;
             """
     ).use {
         it.setString(1, fnr)
         it.setObject(2, startdato)
+        it.setTimestamp(3, Timestamp.from(opprettet.toInstant()))
         it.executeQuery().next()
     }
 


### PR DESCRIPTION
Det hender at vi får satt en tidligere startdato på et sykefravær (kanskje fordi en papirsykmelding har kommet inn?), og da blir det feil å kun behandle meldingene som gjelder den nyeste startdatoen. Derfor må vi se på når de ble opprettet også. 