### PR TITLE
Retry

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -122,7 +122,7 @@ fun main() {
 
     val aktiverMeldingService = AktiverMeldingService(database, smregisterClient, arenaMeldingService, pdlPersonService)
 
-    val kvitteringListener = KvitteringListener(applicationState, kvitteringConsumer, backoutProducer, KvitteringService())
+    val kvitteringListener = KvitteringListener(applicationState, kvitteringConsumer, backoutProducer, KvitteringService(database))
 
     val mottattSykmeldingService = MottattSykmeldingService(database, syfoSyketilfelleClient, arenaMeldingService)
 

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingService.kt
@@ -102,8 +102,8 @@ class AktiverMeldingService(
     private suspend fun sendTilArena(planlagtMelding: PlanlagtMeldingDbModel) {
         if (pdlPersonService.isAlive(planlagtMelding.fnr, planlagtMelding.id)) {
             log.info("Sender melding med id {} til Arena", planlagtMelding.id)
-            arenaMeldingService.sendPlanlagtMeldingTilArena(planlagtMelding)
-            database.sendPlanlagtMelding(planlagtMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
+            val correlationId = arenaMeldingService.sendPlanlagtMeldingTilArena(planlagtMelding)
+            database.sendPlanlagtMelding(planlagtMelding.id, OffsetDateTime.now(ZoneOffset.UTC), correlationId)
             SENDT_MELDING.inc()
         } else {
             log.info("Person er død, avbryter alle planlagte meldinger ${planlagtMelding.id}")

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/ArenaMeldingService.kt
@@ -31,10 +31,10 @@ class ArenaMeldingService(
     private val dateFormat = "ddMMyyyy"
     private val dateTimeFormat = "ddMMyyyy,HHmmss"
 
-    fun sendPlanlagtMeldingTilArena(planlagtMeldingDbModel: PlanlagtMeldingDbModel) {
+    fun sendPlanlagtMeldingTilArena(planlagtMeldingDbModel: PlanlagtMeldingDbModel): String {
         when (planlagtMeldingDbModel.type) {
             BREV_4_UKER_TYPE -> {
-                arenaMqProducer.sendTilArena(
+                return arenaMqProducer.sendTilArena(
                     til4Ukersmelding(
                         planlagtMeldingDbModel,
                         OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
@@ -42,31 +42,28 @@ class ArenaMeldingService(
                 )
             }
             AKTIVITETSKRAV_8_UKER_TYPE -> {
-                arenaMqProducer.sendTilArena(
+                return arenaMqProducer.sendTilArena(
                     til8Ukersmelding(
                         planlagtMeldingDbModel,
                         OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
                     ).tilMqMelding()
-                )
-                log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}")
+                ).also { log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}") }
             }
             BREV_39_UKER_TYPE -> {
-                arenaMqProducer.sendTilArena(
+                return arenaMqProducer.sendTilArena(
                     til39Ukersmelding(
                         planlagtMeldingDbModel,
                         OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
                     ).tilMqMelding()
-                )
-                log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}")
+                ).also { log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}") }
             }
             STANS_TYPE -> {
-                arenaMqProducer.sendTilArena(
+                return arenaMqProducer.sendTilArena(
                     tilStansmelding(
                         planlagtMeldingDbModel,
                         OffsetDateTime.now(ZoneId.of("Europe/Oslo"))
                     ).tilMqMelding()
-                )
-                log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}")
+                ).also { log.info("Sendt melding om ${planlagtMeldingDbModel.type} til Arena, id ${planlagtMeldingDbModel.id}") }
             }
             else -> {
                 log.error(

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/KvitteringService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/KvitteringService.kt
@@ -1,12 +1,14 @@
 package no.nav.syfo.aktivermelding
 
 import no.nav.syfo.aktivermelding.arenamodel.tilKvittering
+import no.nav.syfo.aktivermelding.db.resendPlanlagtMelding
+import no.nav.syfo.application.db.DatabaseInterface
 import no.nav.syfo.application.metrics.KVITTERING_MED_FEIL
 import no.nav.syfo.application.metrics.KVITTERING_SENDT
 import no.nav.syfo.log
 
-class KvitteringService() {
-    fun behandleKvittering(kvitteringsmelding: String) {
+class KvitteringService(private val database: DatabaseInterface) {
+    fun behandleKvittering(kvitteringsmelding: String, correlationId: String) {
         val kvittering = tilKvittering(kvitteringsmelding)
 
         if (kvittering.statusOk == "J") {
@@ -14,8 +16,14 @@ class KvitteringService() {
             KVITTERING_SENDT.inc()
         } else {
             KVITTERING_MED_FEIL.inc()
-            log.error("Melding har feilet i Arena, feilkode: ${kvittering.feilkode}, feilmelding ${kvittering.feilmelding}")
-            throw RuntimeException("Melding har feilet i Arena: ${kvittering.feilkode}")
+            log.error("Melding med id $correlationId har feilet i Arena, feilkode: ${kvittering.feilkode}, feilmelding ${kvittering.feilmelding}")
+            val antallResendteMeldinger = database.resendPlanlagtMelding(correlationId)
+            if (antallResendteMeldinger < 1) {
+                log.error("Fant ikke melding med id $correlationId, kan ikke resende")
+                throw RuntimeException("Melding med id $correlationId har feilet i Arena: ${kvittering.feilkode} og kan ikke resendes")
+            } else {
+                log.info("Resender melding med id $correlationId")
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/MottattSykmeldingService.kt
@@ -68,8 +68,8 @@ class MottattSykmeldingService(
         } else {
             log.info("Sender melding med id {} for sykmeldingid {}", avbruttMelding.id, sykmeldingId)
             database.resendAvbruttMelding(avbruttMelding.id)
-            arenaMeldingService.sendPlanlagtMeldingTilArena(avbruttMelding)
-            database.sendPlanlagtMelding(avbruttMelding.id, OffsetDateTime.now(ZoneOffset.UTC))
+            val correlationId = arenaMeldingService.sendPlanlagtMeldingTilArena(avbruttMelding)
+            database.sendPlanlagtMelding(avbruttMelding.id, OffsetDateTime.now(ZoneOffset.UTC), correlationId)
             SENDT_AVBRUTT_MELDING.inc()
         }
     }

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -36,9 +36,9 @@ fun DatabaseInterface.utsettPlanlagtMelding(id: UUID, sendes: OffsetDateTime) {
     }
 }
 
-fun DatabaseInterface.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime) {
+fun DatabaseInterface.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime, correlationId: String) {
     connection.use { connection ->
-        connection.sendPlanlagtMelding(id, sendt)
+        connection.sendPlanlagtMelding(id, sendt, correlationId)
         connection.commit()
     }
 }
@@ -106,14 +106,15 @@ private fun Connection.utsettPlanlagtMelding(id: UUID, sendes: OffsetDateTime) =
         it.execute()
     }
 
-private fun Connection.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime) =
+private fun Connection.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime, correlationId: String) =
     this.prepareStatement(
         """
-            UPDATE planlagt_melding SET sendt=? WHERE id=?;
+            UPDATE planlagt_melding SET sendt=?, jmscorrelationid=? WHERE id=?;
             """
     ).use {
         it.setTimestamp(1, Timestamp.from(sendt.toInstant()))
-        it.setObject(2, id)
+        it.setString(2, correlationId)
+        it.setObject(3, id)
         it.execute()
     }
 

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/db/DbQueries.kt
@@ -43,6 +43,14 @@ fun DatabaseInterface.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime, corre
     }
 }
 
+fun DatabaseInterface.resendPlanlagtMelding(correlationId: String): Int {
+    connection.use { connection ->
+        val antallResendteMeldinger = connection.resendMelding(correlationId)
+        connection.commit()
+        return antallResendteMeldinger
+    }
+}
+
 fun DatabaseInterface.resendAvbruttMelding(id: UUID) {
     connection.use { connection ->
         connection.resendAvbruttMelding(id)
@@ -116,6 +124,16 @@ private fun Connection.sendPlanlagtMelding(id: UUID, sendt: OffsetDateTime, corr
         it.setString(2, correlationId)
         it.setObject(3, id)
         it.execute()
+    }
+
+private fun Connection.resendMelding(correlationId: String): Int =
+    this.prepareStatement(
+        """
+            UPDATE planlagt_melding SET sendt=null, jmscorrelationid=null WHERE jmscorrelationid=?;
+            """
+    ).use {
+        it.setObject(1, correlationId)
+        it.executeUpdate()
     }
 
 private fun Connection.resendAvbruttMelding(id: UUID) =

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/mq/ArenaMqProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/mq/ArenaMqProducer.kt
@@ -9,8 +9,10 @@ class ArenaMqProducer(
     private val messageProducer: MessageProducer
 ) {
 
-    fun sendTilArena(melding: String) {
-        messageProducer.send(session.createTextMessage().apply(createMessage(melding)))
+    fun sendTilArena(melding: String): String {
+        val message = session.createTextMessage().apply(createMessage(melding))
+        messageProducer.send(message)
+        return message.jmsMessageID
     }
 
     private fun createMessage(melding: String): TextMessage.() -> Unit {

--- a/src/main/kotlin/no/nav/syfo/aktivermelding/mq/KvitteringListener.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivermelding/mq/KvitteringListener.kt
@@ -27,8 +27,9 @@ class KvitteringListener(
                     is TextMessage -> message.text
                     else -> throw RuntimeException("Innkommende melding må være bytes eller tekst")
                 }
-                log.info("Mottatt kvittering")
-                kvitteringService.behandleKvittering(inputMessageText)
+                val correlationId = message.jmsCorrelationID
+                log.info("Mottatt kvittering med correlationId $correlationId")
+                kvitteringService.behandleKvittering(inputMessageText, correlationId)
             } catch (e: Exception) {
                 log.error("Noe gikk galt ved håndtering av kvitteringsmelding, sender melding til backout", e.message)
                 backoutProducer.send(message)

--- a/src/main/kotlin/no/nav/syfo/lagrevedtak/maksdato/MaksdatoService.kt
+++ b/src/main/kotlin/no/nav/syfo/lagrevedtak/maksdato/MaksdatoService.kt
@@ -23,8 +23,8 @@ class MaksdatoService(
 
     suspend fun sendMaksdatomeldingTilArena(utbetaltEvent: UtbetaltEvent) {
         if (skalSendeMaksdatomelding(utbetaltEvent.fnr, utbetaltEvent.forbrukteSykedager, utbetaltEvent.utbetalteventid)) {
-            arenaMqProducer.sendTilArena(tilMaksdatoMelding(utbetaltEvent, OffsetDateTime.now(ZoneId.of("Europe/Oslo"))).tilMqMelding())
-            log.info("Har sendt maksdatomelding for utbetaltevent {}", utbetaltEvent.utbetalteventid)
+            val correlationId = arenaMqProducer.sendTilArena(tilMaksdatoMelding(utbetaltEvent, OffsetDateTime.now(ZoneId.of("Europe/Oslo"))).tilMqMelding())
+            log.info("Har sendt maksdatomelding for utbetaltevent {}, correlationId: {}", utbetaltEvent.utbetalteventid, correlationId)
             SENDT_MAKSDATOMELDING.inc()
         }
     }

--- a/src/main/kotlin/no/nav/syfo/model/PlanlagtMeldingDbModel.kt
+++ b/src/main/kotlin/no/nav/syfo/model/PlanlagtMeldingDbModel.kt
@@ -19,7 +19,8 @@ data class PlanlagtMeldingDbModel(
     val opprettet: OffsetDateTime,
     val sendes: OffsetDateTime,
     val avbrutt: OffsetDateTime? = null,
-    val sendt: OffsetDateTime? = null
+    val sendt: OffsetDateTime? = null,
+    val jmsCorrelationId: String? = null
 )
 
 fun ResultSet.toPlanlagtMeldingDbModel(): PlanlagtMeldingDbModel =
@@ -31,5 +32,6 @@ fun ResultSet.toPlanlagtMeldingDbModel(): PlanlagtMeldingDbModel =
         opprettet = getTimestamp("opprettet").toInstant().atOffset(ZoneOffset.UTC),
         sendes = getTimestamp("sendes").toInstant().atOffset(ZoneOffset.UTC),
         avbrutt = getTimestamp("avbrutt")?.toInstant()?.atOffset(ZoneOffset.UTC),
-        sendt = getTimestamp("sendt")?.toInstant()?.atOffset(ZoneOffset.UTC)
+        sendt = getTimestamp("sendt")?.toInstant()?.atOffset(ZoneOffset.UTC),
+        jmsCorrelationId = getString("jmscorrelationid")
     )

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/AktiverMeldingServiceTest.kt
@@ -4,6 +4,7 @@ import io.ktor.util.KtorExperimentalAPI
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -30,7 +31,7 @@ import org.spekframework.spek2.style.specification.describe
 @KtorExperimentalAPI
 object AktiverMeldingServiceTest : Spek({
     val testDb = TestDB()
-    val arenaMeldingService = mockk<ArenaMeldingService>(relaxed = true)
+    val arenaMeldingService = mockk<ArenaMeldingService>()
     val smregisterClient = mockk<SmregisterClient>()
     val pdlPersonService = mockk<PdlPersonService>()
     val aktiverMeldingService = AktiverMeldingService(testDb, smregisterClient, arenaMeldingService, pdlPersonService)
@@ -38,6 +39,7 @@ object AktiverMeldingServiceTest : Spek({
     beforeEachTest {
         clearAllMocks()
         coEvery { pdlPersonService.isAlive(any(), any()) } returns true
+        every { arenaMeldingService.sendPlanlagtMeldingTilArena(any()) } returns "correlationId"
     }
 
     afterEachTest {
@@ -118,6 +120,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding("fnr", LocalDate.of(2020, 1, 14)).first()
             planlagtMelding.sendt shouldNotEqual null
             planlagtMelding.avbrutt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual "correlationId"
         }
         it("Avbryter 8-ukersmelding hvis bruker ikke lenger er sykmeldt") {
             val id = UUID.randomUUID()
@@ -134,6 +137,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding("fnr", LocalDate.of(2020, 1, 14)).first()
             planlagtMelding.avbrutt shouldNotEqual null
             planlagtMelding.sendt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual null
         }
     }
 
@@ -153,6 +157,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding("fnr", LocalDate.of(2020, 1, 14)).first()
             planlagtMelding.sendt shouldNotEqual null
             planlagtMelding.avbrutt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual "correlationId"
         }
         it("Avbryter 39-ukersmelding hvis bruker ikke lenger er sykmeldt") {
             val id = UUID.randomUUID()
@@ -169,6 +174,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding("fnr", LocalDate.of(2020, 1, 14)).first()
             planlagtMelding.avbrutt shouldNotEqual null
             planlagtMelding.sendt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual null
         }
         it("Avbryter 39-ukersmelding hvis bruker har et nyere sykefravær") {
             val id = UUID.randomUUID()
@@ -205,6 +211,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding("fnr2", LocalDate.of(2020, 5, 10)).first()
             planlagtMelding.sendt shouldNotEqual null
             planlagtMelding.avbrutt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual "correlationId"
         }
     }
 
@@ -246,6 +253,7 @@ object AktiverMeldingServiceTest : Spek({
             val planlagtMelding = testDb.connection.hentPlanlagtMelding(fnr, LocalDate.of(2020, 1, 14)).first()
             planlagtMelding.sendt shouldNotEqual null
             planlagtMelding.avbrutt shouldEqual null
+            planlagtMelding.jmsCorrelationId shouldEqual "correlationId"
         }
         it("Avbryter stansmelding hvis bruker ikke lenger er sykmeldt og det ikke er sendt 4-ukersmelding") {
             val id = UUID.randomUUID()
@@ -283,6 +291,7 @@ object AktiverMeldingServiceTest : Spek({
             planlagtMelding.sendt shouldEqual null
             planlagtMelding.avbrutt shouldEqual null
             planlagtMelding.sendes shouldEqual tom.plusDays(17).atStartOfDay().atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime()
+            planlagtMelding.jmsCorrelationId shouldEqual null
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/aktivermelding/KvitteringServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivermelding/KvitteringServiceTest.kt
@@ -1,6 +1,13 @@
 package no.nav.syfo.aktivermelding
 
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
 import kotlin.test.assertFailsWith
+import no.nav.syfo.testutil.TestDB
+import no.nav.syfo.testutil.dropData
+import no.nav.syfo.testutil.lagrePlanlagtMelding
+import no.nav.syfo.testutil.opprettPlanlagtMelding
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -8,17 +15,36 @@ object KvitteringServiceTest : Spek({
     val kvitteringsmelding = "K278M890Kvittering Arena002270307202010070612345678910J                                                                                                                                                                            "
     val kvitteringsmeldingMedFeil = "K278M890Kvittering Arena002270307202010070612345678910NXXXXXXXXFeilmelding                                                                                                                                                         "
 
-    val kvitteringService = KvitteringService()
+    val testDb = TestDB()
+    val kvitteringService = KvitteringService(testDb)
+
+    afterEachTest {
+        testDb.connection.dropData()
+    }
+
+    afterGroup {
+        testDb.stop()
+    }
 
     describe("Test av behandleKvittering") {
-        it("Feiler hvis kvitteringstatus ikke er ok") {
+        it("Feiler hvis kvitteringstatus ikke er ok og melding ikke finnes i database") {
             assertFailsWith<RuntimeException> {
-                kvitteringService.behandleKvittering(kvitteringsmeldingMedFeil)
+                kvitteringService.behandleKvittering(kvitteringsmeldingMedFeil, "corrId")
             }
         }
+        it("Prøver å resende hvis kvitteringstatus ikke er ok og melding finnes i database") {
+            testDb.connection.lagrePlanlagtMelding(
+                opprettPlanlagtMelding(
+                    id = UUID.randomUUID(),
+                    sendt = OffsetDateTime.now(ZoneOffset.UTC),
+                    jmsCorrelationId = "correlationId"
+                )
+            )
 
+            kvitteringService.behandleKvittering(kvitteringsmeldingMedFeil, "correlationId")
+        }
         it("Feiler ikke hvis kvitteringsstatus er ok") {
-            kvitteringService.behandleKvittering(kvitteringsmelding)
+            kvitteringService.behandleKvittering(kvitteringsmelding, "correlationId")
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
@@ -53,8 +53,9 @@ fun Connection.lagrePlanlagtMelding(planlagtMeldingDbModel: PlanlagtMeldingDbMod
                 opprettet,
                 sendes,
                 avbrutt,
-                sendt)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                sendt,
+                jmscorrelationid)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
              """
     ).use {
         it.setObject(1, planlagtMeldingDbModel.id)
@@ -65,6 +66,7 @@ fun Connection.lagrePlanlagtMelding(planlagtMeldingDbModel: PlanlagtMeldingDbMod
         it.setTimestamp(6, Timestamp.from(planlagtMeldingDbModel.sendes.toInstant()))
         it.setTimestamp(7, if (planlagtMeldingDbModel.avbrutt != null) { Timestamp.from(planlagtMeldingDbModel.avbrutt?.toInstant()) } else { null })
         it.setTimestamp(8, if (planlagtMeldingDbModel.sendt != null) { Timestamp.from(planlagtMeldingDbModel.sendt?.toInstant()) } else { null })
+        it.setString(9, planlagtMeldingDbModel.jmsCorrelationId)
         it.execute()
     }
     this.commit()

--- a/src/test/kotlin/no/nav/syfo/testutil/Testdata.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/Testdata.kt
@@ -28,7 +28,8 @@ fun opprettPlanlagtMelding(
     type: String = AKTIVITETSKRAV_8_UKER_TYPE,
     avbrutt: OffsetDateTime? = null,
     sendt: OffsetDateTime? = null,
-    startdato: LocalDate = LocalDate.of(2020, 1, 14)
+    startdato: LocalDate = LocalDate.of(2020, 1, 14),
+    jmsCorrelationId: String? = null
 ): PlanlagtMeldingDbModel {
     return PlanlagtMeldingDbModel(
         id = id,
@@ -38,7 +39,8 @@ fun opprettPlanlagtMelding(
         type = type,
         sendes = sendes,
         avbrutt = avbrutt,
-        sendt = sendt
+        sendt = sendt,
+        jmsCorrelationId = jmsCorrelationId
     )
 }
 


### PR DESCRIPTION
Dette er kun retry for "planlagte meldinger" som feiler. Maksdatomeldinger som feiler vil inntil videre fortsatt havne på feilkø. 

Akkurat nå er det viktigst å få ut noe som løser de fleste problemene for de planlagte meldingene, men vi har et par forbedringspunkter som vi må komme tilbake til: 
1. Hvordan oppdage at en melding har blitt retryet mange ganger
2. Vurdere om vi skal ha tilsvarende håndtering for maksdatomeldinger (vi var egentlig enig om at maksdatomeldinger er fire and forget, men det kan ha endret seg)