### PR TITLE
må sjekke om gjeldende sykmelding tilhører samme sykefravær før vi ev…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -120,7 +120,7 @@ fun main() {
     val maksdatoService = MaksdatoService(arenaMqProducer, pdlPersonService)
     val utbetaltEventService = UtbetaltEventService(spokelseClient, syfoSyketilfelleClient, lagreUtbetaltEventOgPlanlagtMeldingService, maksdatoService)
 
-    val aktiverMeldingService = AktiverMeldingService(database, smregisterClient, arenaMeldingService, pdlPersonService)
+    val aktiverMeldingService = AktiverMeldingService(database, smregisterClient, arenaMeldingService, pdlPersonService, syfoSyketilfelleClient)
 
     val kvitteringListener = KvitteringListener(applicationState, kvitteringConsumer, backoutProducer, KvitteringService(database))
 

--- a/src/main/kotlin/no/nav/syfo/client/SyfoSyketilfelleClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/SyfoSyketilfelleClient.kt
@@ -37,6 +37,20 @@ class SyfoSyketilfelleClient(
         }
     }
 
+    suspend fun harSykeforlopMedNyereStartdato(aktorId: String, startdato: LocalDate, planlagtMeldingId: UUID): Boolean {
+        val sykeforloep = hentSykeforloep(aktorId)
+        if (sykeforloep.isEmpty()) {
+            log.error("Fant ingen sykeforløp for planlagt melding med id $planlagtMeldingId")
+            if (cluster == "dev-fss") {
+                log.info("Siden dette er dev returnerer vi false, $planlagtMeldingId")
+                return false
+            }
+            throw RuntimeException("Fant ingen sykeforløp for planlagt melding med id $planlagtMeldingId")
+        } else {
+            return sykeforloep.any { it.oppfolgingsdato.isAfter(startdato) }
+        }
+    }
+
     private suspend fun hentSykeforloep(aktorId: String): List<Sykeforloep> =
         httpClient.get<List<Sykeforloep>>("$syketilfelleEndpointURL/sparenaproxy/$aktorId/sykeforloep") {
             accept(ContentType.Application.Json)


### PR DESCRIPTION
…t sender planlagt melding

Hva jeg prøver å løse: Vi sjekker i dag om bruker fortsatt er sykmeldt før vi eventuelt sender planlagte meldinger til Arena. Det fungerer normalt bra, men hvis man har hatt et lengre opphold og så tilfeldigvis har blitt syk igjen akkurat når en planlagt melding skal sendes så ser ikke vi forskjell på om det er et nytt syketilfelle eller om det fortsatt er det gamle, og vi har heller ikke sjekket om vi har sendt stansmelding for oppfølging for det gamle syketilfellet. Det gjør at vi sender meldinger som ikke skulle vært sendt. 

Jeg landet på at det tryggeste kanskje blir at vi gjør følgende når det skal sendes 8- og 39-ukersmelding:
1. Sjekk om bruker fortsatt er sykmeldt (100% for 8-uker og uavhengig av grad for 39-uker), som før
2. Hvis bruker er sykmeldt: Sjekk om vi har sendt stansmelding for syketilfellet som meldingen gjelder for (basert på startdato). Hvis vi ikke har sendt stansmelding så sender vi den planlagte meldingen.
3. Hvis vi har sendt stansmelding: Sjekk mot syfosyketilfelle om bruker har syketilfeller med nyere startdato enn syketilfellet vi skal sende melding for. Hvis bruker har nyere syketilfeller sender vi ikke melding til Arena.

Grunnen til at jeg kun gjør dette for 8- og 39-ukersmeldinger er at vi ikke sender stansmelding hvis det ikke er sendt fireukersmelding. 